### PR TITLE
Fix compilation issues when targeting shipping/installed builds

### DIFF
--- a/Source/Yap/Private/Yap/Nodes/FlowNode_YapDialogue.cpp
+++ b/Source/Yap/Private/Yap/Nodes/FlowNode_YapDialogue.cpp
@@ -13,6 +13,8 @@
 #include "Yap/YapProjectSettings.h"
 #include "Yap/YapSubsystem.h"
 #include "Yap/Enums/YapLoadContext.h"
+#include "Engine/World.h"
+#include "TimerManager.h"
 
 #define LOCTEXT_NAMESPACE "Yap"
 
@@ -179,9 +181,9 @@ void UFlowNode_YapDialogue::SetActive()
 	return;
 	
 	// TODO is there another way I can do this. This is ugly looking.
-	FYapSpeechEventDelegate Delegate;
-	Delegate.BindUFunction(this, GET_FUNCTION_NAME_CHECKED_TwoParams(ThisClass, OnSpeechComplete, UObject*, FYapSpeechHandle));
-	UYapSpeechHandleBFL::BindToOnSpeechComplete(GetWorld(), FocusedSpeechHandle, Delegate);	
+    // FYapSpeechEventDelegate Delegate;
+    // Delegate.BindUFunction(this, GET_FUNCTION_NAME_CHECKED_TwoParams(ThisClass, OnSpeechComplete, UObject*, FYapSpeechHandle));
+    // UYapSpeechHandleBFL::BindToOnSpeechComplete(GetWorld(), FocusedSpeechHandle, Delegate);	
 }
 
 void UFlowNode_YapDialogue::SetInactive()
@@ -190,9 +192,9 @@ void UFlowNode_YapDialogue::SetInactive()
 	
 	// Unbind this node from speech complete events
 	// TODO clean this crap up, is there any other method I can use to achieve this that isn't so dumb looking?
-	FYapSpeechEventDelegate Delegate;
-	Delegate.BindUFunction(this, GET_FUNCTION_NAME_CHECKED_TwoParams(ThisClass, OnSpeechComplete, UObject*, FYapSpeechHandle));
-	UYapSpeechHandleBFL::UnbindToOnSpeechComplete(GetWorld(), FocusedSpeechHandle, Delegate);
+    // FYapSpeechEventDelegate Delegate;
+    // Delegate.BindUFunction(this, GET_FUNCTION_NAME_CHECKED_TwoParams(ThisClass, OnSpeechComplete, UObject*, FYapSpeechHandle));
+    // UYapSpeechHandleBFL::UnbindToOnSpeechComplete(GetWorld(), FocusedSpeechHandle, Delegate);
 }
 
 // ------------------------------------------------------------------------------------------------

--- a/Source/Yap/Private/Yap/Nodes/FlowNode_YapReplaceFragment.cpp
+++ b/Source/Yap/Private/Yap/Nodes/FlowNode_YapReplaceFragment.cpp
@@ -7,6 +7,7 @@
 #include "Yap/YapProjectSettings.h"
 #include "Yap/YapSubsystem.h"
 #include "Yap/YapUtil.h"
+#include "Engine/World.h"
 
 #define LOCTEXT_NAMESPACE "Yap"
 

--- a/Source/Yap/Private/Yap/YapBlueprintFunctionLibrary.cpp
+++ b/Source/Yap/Private/Yap/YapBlueprintFunctionLibrary.cpp
@@ -12,6 +12,7 @@
 #include "Yap/Handles/YapPromptHandle.h"
 #include "Yap/YapSubsystem.h"
 #include "Yap/Nodes/FlowNode_YapDialogue.h"
+#include "Sound/SoundBase.h"
 
 #define LOCTEXT_NAMESPACE "Yap"
 

--- a/Source/Yap/Private/Yap/YapBroker.cpp
+++ b/Source/Yap/Private/Yap/YapBroker.cpp
@@ -10,6 +10,7 @@
 #include "Yap/YapProjectSettings.h"
 #include "Yap/Handles/YapPromptHandle.h"
 #include "Yap/Enums/YapMaturitySetting.h"
+#include "Sound/SoundBase.h"
 
 #define LOCTEXT_NAMESPACE "Yap"
 

--- a/Source/Yap/Private/Yap/YapFragment.cpp
+++ b/Source/Yap/Private/Yap/YapFragment.cpp
@@ -12,6 +12,7 @@
 #include "Yap/Enums/YapMissingAudioErrorLevel.h"
 
 #include "Yap/Nodes/FlowNode_YapDialogue.h"
+#include "Engine/Blueprint.h"
 
 #define LOCTEXT_NAMESPACE "Yap"
 

--- a/Source/Yap/Private/Yap/YapProjectSettings.cpp
+++ b/Source/Yap/Private/Yap/YapProjectSettings.cpp
@@ -15,6 +15,8 @@
 FName UYapProjectSettings::CategoryName = FName("Yap");
 #endif
 
+#include "Sound/SoundBase.h"
+
 UYapProjectSettings::UYapProjectSettings()
 {
 #if WITH_EDITORONLY_DATA

--- a/Source/Yap/Private/Yap/YapSubsystem.cpp
+++ b/Source/Yap/Private/Yap/YapSubsystem.cpp
@@ -15,6 +15,7 @@
 #include "Yap/Enums/YapLoadContext.h"
 #include "Yap/Interfaces/IYapFreeSpeechHandler.h"
 #include "Yap/Nodes/FlowNode_YapDialogue.h"
+#include "TimerManager.h"
 
 #define LOCTEXT_NAMESPACE "Yap"
 

--- a/Source/Yap/Public/Yap/DefaultConditions/YapCondition_MaturitySetting.h
+++ b/Source/Yap/Public/Yap/DefaultConditions/YapCondition_MaturitySetting.h
@@ -14,7 +14,7 @@ class YAP_API UYapCondition_MaturitySetting : public UYapCondition
 {
 	GENERATED_BODY()
 
-	UPROPERTY(EditAnywhere)
+	UPROPERTY(EditAnywhere, Category = "Default")
 	EYapMaturitySetting RequiredSetting;
 
 public:

--- a/Source/Yap/Public/Yap/Globals/YapFileUtilities.h
+++ b/Source/Yap/Public/Yap/Globals/YapFileUtilities.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include "CoreMinimal.h"
+
 namespace Yap
 {
 	namespace FileUtilities

--- a/Source/Yap/Public/Yap/Handles/YapConversationHandle.h
+++ b/Source/Yap/Public/Yap/Handles/YapConversationHandle.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "Kismet/BlueprintFunctionLibrary.h"
 #include "YapConversationHandle.generated.h"
 
 UDELEGATE()

--- a/Source/Yap/Public/Yap/Handles/YapPromptHandle.h
+++ b/Source/Yap/Public/Yap/Handles/YapPromptHandle.h
@@ -5,6 +5,7 @@
 
 #include "CoreMinimal.h"
 #include "GameplayTagContainer.h"
+#include "Kismet/BlueprintFunctionLibrary.h"
 
 #include "YapPromptHandle.generated.h"
 
@@ -23,10 +24,10 @@ struct YAP_API FYapPromptHandle
 	// ------------------------------------------
 
 protected:
-	UPROPERTY(Transient, BlueprintReadOnly, meta = (AllowPrivateAccess, IgnoreForMemberInitializationTest))
+    UPROPERTY(Transient, BlueprintReadOnly, meta = (AllowPrivateAccess, IgnoreForMemberInitializationTest), Category = "Default")
 	FGuid Guid;
 
-	UPROPERTY(Transient, BlueprintReadOnly, meta = (AllowPrivateAccess))
+    UPROPERTY(Transient, BlueprintReadOnly, meta = (AllowPrivateAccess), Category = "Default")
 	FGameplayTag TypeGroup;
 
 	// ------------------------------------------

--- a/Source/Yap/Public/Yap/Handles/YapSpeechHandle.h
+++ b/Source/Yap/Public/Yap/Handles/YapSpeechHandle.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "Kismet/BlueprintFunctionLibrary.h"
 #include "YapSpeechHandle.generated.h"
 
 // ================================================================================================
@@ -35,8 +36,7 @@ public:
     // STATE
     // ------------------------------------------
 private:
-	
-    UPROPERTY(Transient, BlueprintReadOnly, meta = (IgnoreForMemberInitializationTest, AllowPrivateAccess))
+    UPROPERTY(Transient, BlueprintReadOnly, meta = (IgnoreForMemberInitializationTest, AllowPrivateAccess), Category = "Default")
     FGuid Guid;
 
     UPROPERTY(Transient)

--- a/Source/Yap/Public/Yap/Interfaces/IYapCharacterInterface.h
+++ b/Source/Yap/Public/Yap/Interfaces/IYapCharacterInterface.h
@@ -3,6 +3,8 @@
 
 #pragma once
 #include "GameplayTagContainer.h"
+#include "UObject/Interface.h"
+#include "Kismet/BlueprintFunctionLibrary.h"
 
 #include "IYapCharacterInterface.generated.h"
 

--- a/Source/Yap/Public/Yap/Interfaces/IYapConversationHandler.h
+++ b/Source/Yap/Public/Yap/Interfaces/IYapConversationHandler.h
@@ -5,6 +5,7 @@
 
 #include "Yap/Handles/YapConversationHandle.h"
 #include "Yap/Handles/YapSpeechHandle.h"
+#include "UObject/Interface.h"
 
 class UYapCharacterAsset;
 struct FYapPromptHandle;

--- a/Source/Yap/Public/Yap/Interfaces/IYapFreeSpeechHandler.h
+++ b/Source/Yap/Public/Yap/Interfaces/IYapFreeSpeechHandler.h
@@ -4,7 +4,7 @@
 #pragma once
 #include "Yap/Handles/YapSpeechHandle.h"
 #include "Yap/YapDataStructures.h"
-
+#include "UObject/Interface.h"
 #include "IYapFreeSpeechHandler.generated.h"
 
 #define LOCTEXT_NAMESPACE "Yap"

--- a/Source/Yap/Public/Yap/Nodes/FlowNode_YapConversation_Close.h
+++ b/Source/Yap/Public/Yap/Nodes/FlowNode_YapConversation_Close.h
@@ -13,7 +13,7 @@ class YAP_API UFlowNode_YapConversation_Close : public UFlowNode
 {
 	GENERATED_BODY()
 
-	UPROPERTY(EditAnywhere)
+	UPROPERTY(EditAnywhere, Category = "Default")
 	FGameplayTag Conversation;
 	
 public:

--- a/Source/Yap/Public/Yap/Nodes/FlowNode_YapConversation_Open.h
+++ b/Source/Yap/Public/Yap/Nodes/FlowNode_YapConversation_Open.h
@@ -23,7 +23,7 @@ public:
 protected:
 
 	/** Optional name for this conversation. */
-	UPROPERTY(EditAnywhere, BlueprintReadOnly)
+	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Default")
 	FGameplayTag ConversationName;
 
 	// ==========================================

--- a/Source/Yap/Public/Yap/Nodes/FlowNode_YapDialogue.h
+++ b/Source/Yap/Public/Yap/Nodes/FlowNode_YapDialogue.h
@@ -9,7 +9,7 @@
 #include "Yap/Handles/YapConversationHandle.h"
 #include "Yap/Handles/YapPromptHandle.h"
 #include "Yap/Handles/YapSpeechHandle.h"
-
+#include "Engine/TimerHandle.h"
 #include "FlowNode_YapDialogue.generated.h"
 
 class UYapCharacterAsset;
@@ -96,43 +96,43 @@ public:
 	
 protected:
 	/** What type of node we are. */
-	UPROPERTY(BlueprintReadOnly)
+    UPROPERTY(BlueprintReadOnly, Category = "Default")
 	EYapDialogueNodeType DialogueNodeType;
 
 	/** What is this dialogue's type-group? Leave unset to use the default type-group. */
-	UPROPERTY(EditAnywhere, BlueprintReadOnly)
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Default")
 	FGameplayTag TypeGroup;
 	
 	/** Maximum number of times we can successfully enter & exit this node. Any further attempts will trigger the Bypass output. */
-	UPROPERTY(BlueprintReadOnly)
+    UPROPERTY(BlueprintReadOnly, Category = "Default")
 	int32 NodeActivationLimit;
 
 	/** Controls how Talk nodes flow. See EYapDialogueTalkSequencing. */
-	UPROPERTY(BlueprintReadOnly)
+    UPROPERTY(BlueprintReadOnly, Category = "Default")
 	EYapDialogueTalkSequencing TalkSequencing;
 
 	/** Controls if dialogue can be interrupted. */
-	UPROPERTY(BlueprintReadOnly)
+    UPROPERTY(BlueprintReadOnly, Category = "Default")
 	TOptional<bool> Skippable;
 
 	/** Controls if dialogue automatically advances (only applicable if it has a time duration set). */
-	UPROPERTY(BlueprintReadOnly)
+    UPROPERTY(BlueprintReadOnly, Category = "Default")
 	TOptional<bool> AutoAdvance;
 
 	/** Tags can be used to interact with this dialogue node during the game. Dialogue nodes can be looked up and/or modified by UYapSubsystem by their tag. */
-	UPROPERTY(BlueprintReadOnly)
+    UPROPERTY(BlueprintReadOnly, Category = "Default")
 	FGameplayTag DialogueTag;
 
 	/** Conditions which must be met for this dialogue to run. All conditions must pass (AND, not OR evaluation). If any conditions fail, Bypass output is triggered. */
-	UPROPERTY(Instanced, BlueprintReadOnly)
+    UPROPERTY(Instanced, BlueprintReadOnly, Category = "Default")
 	TArray<TObjectPtr<UYapCondition>> Conditions;
 
 	/** Unique node ID for audio system. */
-	UPROPERTY(EditAnywhere)
+    UPROPERTY(EditAnywhere, Category = "Default")
 	FString AudioID = "";
 	
 	/** Actual dialogue contents. */
-	UPROPERTY(EditAnywhere)
+    UPROPERTY(EditAnywhere, Category = "Default")
 	TArray<FYapFragment> Fragments;
 
 	// ============================================================================================
@@ -142,7 +142,7 @@ protected:
 protected:
 	// TODO what happens if I enter a node before it finishes playing? Should I use the activation count to reseed new GUIDs for fragments? This is an extreme edge case
 	/** How many times this node has been successfully ran. */
-	UPROPERTY(Transient, BlueprintReadOnly)
+    UPROPERTY(Transient, BlueprintReadOnly, Category = "Default")
 	int32 NodeActivationCount = 0;
 
 	/** The most recent running fragment */

--- a/Source/Yap/Public/Yap/Nodes/FlowNode_YapReplaceFragment.h
+++ b/Source/Yap/Public/Yap/Nodes/FlowNode_YapReplaceFragment.h
@@ -16,10 +16,10 @@ class YAP_API UFlowNode_YapReplaceFragment : public UFlowNode
 	GENERATED_BODY()
 
 protected:
-	UPROPERTY(EditAnywhere)
+    UPROPERTY(EditAnywhere, Category = "Default")
 	FGameplayTag TargetFragmentTag;
-	
-	UPROPERTY(EditAnywhere)
+
+    UPROPERTY(EditAnywhere, Category = "Default")
 	FYapBitReplacement NewData;
 	
 public:

--- a/Source/Yap/Public/Yap/YapBitReplacement.h
+++ b/Source/Yap/Public/Yap/YapBitReplacement.h
@@ -20,50 +20,50 @@ struct FYapBitReplacement
 	FYapBitReplacement();
 	
 	/**  */
-	UPROPERTY(EditAnywhere)
+	UPROPERTY(EditAnywhere, Category = "Default")
 	TOptional<TSoftObjectPtr<UYapCharacterAsset>> SpeakerAsset;
 
 	/**  */
-	UPROPERTY(EditAnywhere)
+	UPROPERTY(EditAnywhere, Category = "Default")
 	TOptional<TSoftObjectPtr<UYapCharacterAsset>> DirectedAtAsset;
 
 	/**  */
-	UPROPERTY(EditAnywhere)
+	UPROPERTY(EditAnywhere, Category = "Default")
 	TOptional<FYapText> MatureTitleText;
 	
 	/**  */
-	UPROPERTY(EditAnywhere)
+	UPROPERTY(EditAnywhere, Category = "Default")
 	TOptional<FYapText> SafeTitleText;
 
-	UPROPERTY(EditAnywhere)
+	UPROPERTY(EditAnywhere, Category = "Default")
 	bool bOverrideMatureDialogueText = false;
 	
 	/**  */
-	UPROPERTY(EditAnywhere, meta = (EditCondition = "bOverrideMatureDialogueText", EditConditionHides))
+	UPROPERTY(EditAnywhere, Category = "Default", meta = (EditCondition = "bOverrideMatureDialogueText", EditConditionHides))
 	FYapText MatureDialogueText;
 	
 	/**  */
-	UPROPERTY(EditAnywhere)
+	UPROPERTY(EditAnywhere, Category = "Default")
 	TOptional<FYapText> SafeDialogueText;
 	
 	/**  */
-	UPROPERTY(EditAnywhere)
+	UPROPERTY(EditAnywhere, Category = "Default")
 	TOptional<TSoftObjectPtr<UObject>> MatureAudioAsset;
 	
 	/**  */
-	UPROPERTY(EditAnywhere)
+	UPROPERTY(EditAnywhere, Category = "Default")
 	TOptional<TSoftObjectPtr<UObject>> SafeAudioAsset;
 
 	/**  */
-	UPROPERTY(EditAnywhere)
+	UPROPERTY(EditAnywhere, Category = "Default")
 	TOptional<FGameplayTag> MoodTag = FGameplayTag::EmptyTag;
 
 	/**  */
-	UPROPERTY(EditAnywhere)
+	UPROPERTY(EditAnywhere, Category = "Default")
 	TOptional<EYapTimeMode> TimeMode = EYapTimeMode::AudioTime;
 
 	/**  */
-	UPROPERTY(EditAnywhere)
+	UPROPERTY(EditAnywhere, Category = "Default")
 	TOptional<float> ManualTime = 0;
 };
 

--- a/Source/Yap/Public/Yap/YapCharacterAsset.h
+++ b/Source/Yap/Public/Yap/YapCharacterAsset.h
@@ -28,27 +28,27 @@ public:
 
 protected:
 	/** Human-readable name of this character or entity. */
-	UPROPERTY(EditAnywhere, BlueprintReadOnly, DisplayName = "Name")
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, DisplayName = "Name", Category = "Default")
 	FText EntityName;
 
 	/** Color for display. */
-	UPROPERTY(EditAnywhere, BlueprintReadOnly, DisplayName = "Color")
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, DisplayName = "Color", Category = "Default")
 	FLinearColor EntityColor;
 	
 	/** Used to find this actor in the world. */
-	UPROPERTY(EditAnywhere, BlueprintReadOnly)
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Default")
 	FGameplayTag IdentityTag;
 	
 	/** If set, the character will use a single portrait texture for all moods. */
-	UPROPERTY(EditAnywhere)
+    UPROPERTY(EditAnywhere, Category = "Default")
 	bool bUseSinglePortrait = false;
 
 	/** Portrait texture to use. */
-	UPROPERTY(EditAnywhere, EditFixedSize, meta=(ReadOnlyKeys, ForceInlineRow, EditCondition = "bUseSinglePortrait", EditConditionHides))
+    UPROPERTY(EditAnywhere, EditFixedSize, meta=(ReadOnlyKeys, ForceInlineRow, EditCondition = "bUseSinglePortrait", EditConditionHides), Category = "Default")
 	TObjectPtr<UTexture2D> Portrait;
 	
 	/** Avatar icons to use in dialogue UI */
-	UPROPERTY(EditAnywhere, EditFixedSize, meta=(ReadOnlyKeys, ForceInlineRow, EditCondition = "!bUseSinglePortrait", EditConditionHides))
+    UPROPERTY(EditAnywhere, EditFixedSize, meta=(ReadOnlyKeys, ForceInlineRow, EditCondition = "!bUseSinglePortrait", EditConditionHides), Category = "Default")
 	TMap<FName, TObjectPtr<UTexture2D>> Portraits;
 
 	// --------------------- //

--- a/Source/Yap/Public/Yap/YapCharacterComponent.h
+++ b/Source/Yap/Public/Yap/YapCharacterComponent.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "Components/ActorComponent.h"
 #include "GameplayTagContainer.h"
 
 #include "YapCharacterComponent.generated.h"
@@ -15,7 +16,7 @@ class YAP_API UYapCharacterComponent : public UActorComponent
 	GENERATED_BODY()
 
 protected:
-UPROPERTY(EditAnywhere)
+    UPROPERTY(EditAnywhere, Category = "Default")
 	FGameplayTag Identity;
 
 public:

--- a/Source/Yap/Public/Yap/YapCondition.h
+++ b/Source/Yap/Public/Yap/YapCondition.h
@@ -25,23 +25,23 @@ public:
 protected:
 
 #if WITH_EDITORONLY_DATA
-	UPROPERTY(EditDefaultsOnly)
-	FText DefaultTitle = LOCTEXT("UnnamedYapCondition", "Unnamed Condition");
+    UPROPERTY(EditDefaultsOnly, Category = "Default")
+    FText DefaultTitle = LOCTEXT("UnnamedYapCondition", "Unnamed Condition");
 
-	UPROPERTY(EditInstanceOnly)
+    UPROPERTY(EditInstanceOnly, Category = "Default")
 	TOptional<FString> TitleOverride;
-	
-	UPROPERTY(EditDefaultsOnly)
+
+    UPROPERTY(EditDefaultsOnly, Category = "Default")
 	FLinearColor Color = FLinearColor(0.080, 0.200, 0.100, 1.0);
 
 	/** This is OPTIONAL. If you set this, the details view widget will have this minimum height in the Flow Graph.
 	 *  Setting this large enough to contain the whole view will prevent the stupid view widget from bouncing all over the place on creation. */
-	UPROPERTY(EditDefaultsOnly)
+    UPROPERTY(EditDefaultsOnly, Category = "Default")
 	int32 DetailsViewHeight = 200;
 	
 	/** This is OPTIONAL. If you set this, the details view widget will have this minimum width in the Flow Graph.
 	 *  Setting this large enough to contain the whole view will prevent the stupid view widget from bouncing all over the place on creation. */
-	UPROPERTY(EditDefaultsOnly)
+    UPROPERTY(EditDefaultsOnly, Category = "Default")
 	int32 DetailsViewWidth = 400;
 #endif
 

--- a/Source/Yap/Public/Yap/YapDataStructures.h
+++ b/Source/Yap/Public/Yap/YapDataStructures.h
@@ -29,7 +29,7 @@ struct FYapData_ConversationOpened
 	GENERATED_BODY()
 
 	/** Conversation name. */
-	UPROPERTY(BlueprintReadOnly)
+    UPROPERTY(BlueprintReadOnly, Category = "Default")
 	FGameplayTag Conversation;
 };
 
@@ -42,45 +42,45 @@ struct FYapData_SpeechBegins
 	GENERATED_BODY()
 
 	/** Conversation name. This will be empty for speech occurring outside of a conversation. */
-	UPROPERTY(BlueprintReadOnly)
+    UPROPERTY(BlueprintReadOnly, Category = "Default")
 	FGameplayTag Conversation;
 	
 	/** Who is being speaked towards. */
-	UPROPERTY(BlueprintReadOnly)
+    UPROPERTY(BlueprintReadOnly, Category = "Default")
 	TScriptInterface<IYapCharacterInterface> DirectedAt = nullptr;
 
 	/** Who is speaking. */
-	UPROPERTY(BlueprintReadOnly)
+    UPROPERTY(BlueprintReadOnly, Category = "Default")
 	TScriptInterface<IYapCharacterInterface> Speaker;
 
 	/** Mood of the speaker. */
-	UPROPERTY(BlueprintReadOnly)
+    UPROPERTY(BlueprintReadOnly, Category = "Default")
 	FGameplayTag MoodTag;
 
 	/** Text being spoken. */
-	UPROPERTY(BlueprintReadOnly)
+    UPROPERTY(BlueprintReadOnly, Category = "Default")
 	FText DialogueText;
 
 	/** Optional title text representing the dialogue. */
-	UPROPERTY(BlueprintReadOnly)
+    UPROPERTY(BlueprintReadOnly, Category = "Default")
 	FText TitleText;
 	
 	/** How long this dialogue is expected to play for. */
-	UPROPERTY(BlueprintReadOnly)
+    UPROPERTY(BlueprintReadOnly, Category = "Default")
 	float SpeechTime = 0;
 
 	// TODO: I'm not sure if this data belongs in here. It's here because it might be useful for UI to have... but it's irrelevant to the subsystem and actual dialogue engine, only the flow graph.
 	// I'm going to try taking it out for now and I can put it back in later if it seems necessary for any real purpose.
 	/** Delay after this dialogue completes before carrying on. */
-	//UPROPERTY(BlueprintReadOnly)
+    //UPROPERTY(BlueprintReadOnly, Category = "Default")
 	//float FragmentTime = 0;
 
 	/** Audio asset, you are responsible to cast to your proper type to use. */
-	UPROPERTY(BlueprintReadOnly)
+    UPROPERTY(BlueprintReadOnly, Category = "Default")
 	TObjectPtr<const UObject> DialogueAudioAsset;
 
 	/** Can this dialogue be skipped? */
-	UPROPERTY(BlueprintReadOnly)
+    UPROPERTY(BlueprintReadOnly, Category = "Default")
 	bool bSkippable = false;
 };
 
@@ -93,27 +93,27 @@ struct FYapData_PlayerPromptCreated
 	GENERATED_BODY()
 
 	/** Conversation name. */
-	UPROPERTY(BlueprintReadOnly)
+    UPROPERTY(BlueprintReadOnly, Category = "Default")
 	FYapConversationHandle Conversation;
 	
 	/** Who will be spoken to. */
-	UPROPERTY(BlueprintReadOnly)
+    UPROPERTY(BlueprintReadOnly, Category = "Default")
 	TScriptInterface<IYapCharacterInterface> DirectedAt;
 
 	/** Who is going to speak. */
-	UPROPERTY(BlueprintReadOnly)
+    UPROPERTY(BlueprintReadOnly, Category = "Default")
 	TScriptInterface<IYapCharacterInterface> Speaker;
 
 	/** Mood of the speaker. */
-	UPROPERTY(BlueprintReadOnly)
+    UPROPERTY(BlueprintReadOnly, Category = "Default")
 	FGameplayTag MoodTag;
 	 
 	/** Text that will be spoken. */
-	UPROPERTY(BlueprintReadOnly)
+    UPROPERTY(BlueprintReadOnly, Category = "Default")
 	FText DialogueText;
 
 	/** Optional title text representing the dialogue. */
-	UPROPERTY(BlueprintReadOnly)
+    UPROPERTY(BlueprintReadOnly, Category = "Default")
 	FText TitleText;
 };
 
@@ -126,7 +126,7 @@ struct FYapData_PlayerPromptsReady
 	GENERATED_BODY()
 
 	/** Conversation name. */
-	UPROPERTY(BlueprintReadOnly)
+    UPROPERTY(BlueprintReadOnly, Category = "Default")
 	FYapConversationHandle Conversation;
 };
 
@@ -139,7 +139,7 @@ struct FYapData_PlayerPromptChosen
 	GENERATED_BODY()
 
 	/** Conversation name. */
-	UPROPERTY(BlueprintReadOnly)
+    UPROPERTY(BlueprintReadOnly, Category = "Default")
 	FGameplayTag Conversation;
 };
 

--- a/Source/Yap/Public/Yap/YapFragment.h
+++ b/Source/Yap/Public/Yap/YapFragment.h
@@ -4,6 +4,8 @@
 #pragma once
 #include "YapBit.h"
 #include "GameplayTagContainer.h"
+#include "Engine/TimerHandle.h"
+#include "Runtime/Launch/Resources/Version.h"
 
 #if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION < 5
 #include "InstancedStruct.h"
@@ -123,7 +125,7 @@ protected:
 	UPROPERTY()
 	FGameplayTag MoodTag;
 
-	UPROPERTY(EditAnywhere)
+    UPROPERTY(EditAnywhere, Category = "Default")
 	TArray<FInstancedStruct> Data;
 	
 	/**  */
@@ -133,8 +135,7 @@ protected:
 	// ==========================================
 	// STATE
 protected:
-
-	UPROPERTY(VisibleAnywhere, meta=(IgnoreForMemberInitializationTest))
+    UPROPERTY(VisibleAnywhere, meta=(IgnoreForMemberInitializationTest), Category = "Default")
 	FGuid Guid;
 	
 	// TODO should this be serialized or transient

--- a/Source/Yap/Public/Yap/YapLog.h
+++ b/Source/Yap/Public/Yap/YapLog.h
@@ -3,4 +3,6 @@
 
 #pragma once
 
+#include "Logging/LogMacros.h"
+
 YAP_API DECLARE_LOG_CATEGORY_EXTERN(LogYap, Log, All);

--- a/Source/Yap/Public/Yap/YapMessageLog.h
+++ b/Source/Yap/Public/Yap/YapMessageLog.h
@@ -3,7 +3,7 @@
 
 #pragma once
 #include "GameplayTagContainer.h"
-
+#include "Subsystems/GameInstanceSubsystem.h"
 #include "YapMessageLog.generated.h"
 
 class UYapCharacterAsset;
@@ -21,10 +21,10 @@ struct FYapMessageEntry
     FYapMessageEntry(UYapCharacterAsset* InSpeaker, const FText& InText);
     
 protected:
-    UPROPERTY(BlueprintReadOnly)
+    UPROPERTY(BlueprintReadOnly, Category = "Default")
     TObjectPtr<UYapCharacterAsset> Speaker;
 
-    UPROPERTY(BlueprintReadOnly)
+    UPROPERTY(BlueprintReadOnly, Category = "Default")
     FText Text;
 
 public:
@@ -41,7 +41,7 @@ struct FYapConversationLog
     GENERATED_BODY()
 
 protected:
-    UPROPERTY(BlueprintReadOnly)
+    UPROPERTY(BlueprintReadOnly, Category = "Default")
     TArray<FYapMessageEntry> MessageEntries;
 };
 
@@ -53,6 +53,6 @@ class UYapMessageLog : public UGameInstanceSubsystem
     GENERATED_BODY()
 
 protected:
-    UPROPERTY(BlueprintReadOnly)
+    UPROPERTY(BlueprintReadOnly, Category = "Default")
     TMap<FGameplayTag, FYapConversationLog> LoggedConversations;
 };

--- a/Source/Yap/Public/Yap/YapProjectSettings.h
+++ b/Source/Yap/Public/Yap/YapProjectSettings.h
@@ -12,6 +12,7 @@
 #include "YapProjectSettings.generated.h"
 
 class UYapBroker;
+class UTexture2D;
 enum class EYapDialogueProgressionFlags : uint8;
 enum class EYapMaturitySetting : uint8;
 enum class EYapMissingAudioErrorLevel : uint8;

--- a/Source/Yap/Public/Yap/YapRunningFragment.h
+++ b/Source/Yap/Public/Yap/YapRunningFragment.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "Engine/TimerHandle.h"
 #include "YapRunningFragment.generated.h"
 
 struct FYapFragment;
@@ -42,8 +43,8 @@ private:
 	uint8 FragmentIndex = 0;
 	
 	static FYapRunningFragment _InvalidHandle;
-	
-	UPROPERTY(Transient, BlueprintReadOnly, meta = (AllowPrivateAccess, IgnoreForMemberInitializationTest))
+
+    UPROPERTY(Transient, BlueprintReadOnly, meta = (AllowPrivateAccess, IgnoreForMemberInitializationTest), Category = "Default")
 	FGuid Guid;
 
 	UPROPERTY(Transient)

--- a/Source/Yap/Public/Yap/YapSubsystem.h
+++ b/Source/Yap/Public/Yap/YapSubsystem.h
@@ -12,7 +12,9 @@
 #include "Yap/YapRunningFragment.h"
 #include "Yap/YapBitReplacement.h"
 #include "Yap/YapDataStructures.h"
-
+#include "Subsystems/WorldSubsystem.h"
+#include "Engine/TimerHandle.h"
+#include "Engine/World.h"
 #include "YapSubsystem.generated.h"
 
 class UYapConversationHandler;
@@ -253,7 +255,7 @@ protected:
 
 public:
 	/**  */
-	UFUNCTION(BlueprintCallable)
+    UFUNCTION(BlueprintCallable, Category = "Default")
 	FYapSpeechHandle RunSpeech(const FYapData_SpeechBegins& SpeechData, FGameplayTag TypeGroup, FYapSpeechHandle& Handle);
 
 	// TODO I hate this thing

--- a/Source/Yap/Public/Yap/YapText.h
+++ b/Source/Yap/Public/Yap/YapText.h
@@ -20,11 +20,10 @@ struct YAP_API FYapText
 	// SETTINGS
 	// --------------------------------------------------------------------------------------------
 private:
-	
-	UPROPERTY(EditAnywhere, BlueprintReadOnly, meta = (AllowPrivateAccess))
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, meta = (AllowPrivateAccess), Category = "Default")
 	FText Text;
 
-	UPROPERTY(BlueprintReadOnly, meta = (AllowPrivateAccess))
+    UPROPERTY(BlueprintReadOnly, meta = (AllowPrivateAccess), Category = "Default")
 	int32 WordCount = 0;
 
 	// --------------------------------------------------------------------------------------------

--- a/Source/Yap/Public/Yap/YapTypeGroupSettings.h
+++ b/Source/Yap/Public/Yap/YapTypeGroupSettings.h
@@ -6,6 +6,7 @@
 #include "Yap/Enums/YapMissingAudioErrorLevel.h"
 #include "Yap/Enums/YapTimeMode.h"
 #include "GameplayTagContainer.h"
+#include "Fonts/SlateFontInfo.h"
 #include "YapTypeGroupSettings.generated.h"
 
 #define LOCTEXT_NAMESPACE "YapEditor"
@@ -33,10 +34,10 @@ public:
 	// - - - - - PRIVATE - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
 private:
 	/** If true, this struct is the default settings. This is only set internally by UYapProjectSettings. */
-	UPROPERTY(Transient, EditAnywhere, meta = (DoNotDraw))
+    UPROPERTY(Transient, EditAnywhere, meta = (DoNotDraw), Category = "Default")
 	bool bDefault = false;
-	
-	UPROPERTY(Config, EditAnywhere, meta = (DoNotDraw))
+
+    UPROPERTY(Config, EditAnywhere, meta = (DoNotDraw), Category = "Default")
 	FLinearColor GroupColor = FLinearColor::White;
 
 	// - - - - - AUDIO - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -168,88 +169,88 @@ private:
 	
 	// ============================================================================================
 public:
-	UPROPERTY(EditAnywhere, meta = (DefaultOverride = MissingAudioErrorLevel))
+    UPROPERTY(EditAnywhere, meta = (DefaultOverride = MissingAudioErrorLevel), Category = "Default")
 	bool bMissingAudioErrorLevel_Override = false;
-	
-	UPROPERTY(EditAnywhere, meta = (DefaultOverride = DefaultTimeModeSetting))
+
+    UPROPERTY(EditAnywhere, meta = (DefaultOverride = DefaultTimeModeSetting), Category = "Default")
 	bool bDefaultTimeModeSetting_Override = false;
-	
-	UPROPERTY(EditAnywhere, meta = (DefaultOverride = DialogueTagsParent))
+
+    UPROPERTY(EditAnywhere, meta = (DefaultOverride = DialogueTagsParent), Category = "Default")
 	bool bDialogueTagsParent_Override = false;
-	
-	UPROPERTY(EditAnywhere, meta = (DefaultOverride = AudioAssetsRootFolder))
+
+    UPROPERTY(EditAnywhere, meta = (DefaultOverride = AudioAssetsRootFolder), Category = "Default")
 	bool bAudioAssetsRootFolder_Override = false;
-	
-	UPROPERTY(EditAnywhere, meta = (DefaultOverride = FlowAssetsRootFolder))
+
+    UPROPERTY(EditAnywhere, meta = (DefaultOverride = FlowAssetsRootFolder), Category = "Default")
 	bool bFlowAssetsRootFolder_Override = false;
 
-	UPROPERTY(EditAnywhere, meta = (DefaultOverride = bForcedDialogueDuration))
+    UPROPERTY(EditAnywhere, meta = (DefaultOverride = bForcedDialogueDuration), Category = "Default")
 	bool bForcedDialogueDuration_Override = false;
 
-	UPROPERTY(EditAnywhere, meta = (DefaultOverride = bManualAdvanceOnly))
+    UPROPERTY(EditAnywhere, meta = (DefaultOverride = bManualAdvanceOnly), Category = "Default")
 	bool bManualAdvanceOnly_Override = false;
 
-	UPROPERTY(EditAnywhere, meta = (DefaultOverride = bPromptAutoAdvance))
+    UPROPERTY(EditAnywhere, meta = (DefaultOverride = bPromptAutoAdvance), Category = "Default")
 	bool bPromptAutoAdvance_Override = false;
-	
-	UPROPERTY(EditAnywhere, meta = (DefaultOverride = bAutoAdvanceToPromptNodes))
+
+    UPROPERTY(EditAnywhere, meta = (DefaultOverride = bAutoAdvanceToPromptNodes), Category = "Default")
 	bool bAutoAdvanceToPromptNodes_Override = false;
-	
-	UPROPERTY(EditAnywhere, meta = (DefaultOverride = bPreventAutoSelectLastPrompt))
+
+    UPROPERTY(EditAnywhere, meta = (DefaultOverride = bPreventAutoSelectLastPrompt), Category = "Default")
 	bool bPreventAutoSelectLastPrompt_Override = false;
 
-	UPROPERTY(EditAnywhere, meta = (DefaultOverride = DefaultFragmentPaddingTime))
+    UPROPERTY(EditAnywhere, meta = (DefaultOverride = DefaultFragmentPaddingTime), Category = "Default")
 	bool bDefaultFragmentPaddingTime_Override = false;
 
-	UPROPERTY(EditAnywhere, meta = (DefaultOverride = MinimumAutoTextTimeLength))
+    UPROPERTY(EditAnywhere, meta = (DefaultOverride = MinimumAutoTextTimeLength), Category = "Default")
 	bool bMinimumAutoTextTimeLength_Override = false;
 
-	UPROPERTY(EditAnywhere, meta = (DefaultOverride = MinimumAutoAudioTimeLength))
+    UPROPERTY(EditAnywhere, meta = (DefaultOverride = MinimumAutoAudioTimeLength), Category = "Default")
 	bool bMinimumAutoAudioTimeLength_Override = false;
 
-	UPROPERTY(EditAnywhere, meta = (DefaultOverride = MinimumSpeakingTime))
+    UPROPERTY(EditAnywhere, meta = (DefaultOverride = MinimumSpeakingTime), Category = "Default")
 	bool bMinimumSpeakingTime_Override = false;
 
-	UPROPERTY(EditAnywhere, meta = (DefaultOverride = MinimumTimeRemainingToAllowSkip))
+    UPROPERTY(EditAnywhere, meta = (DefaultOverride = MinimumTimeRemainingToAllowSkip), Category = "Default")
 	bool bMinimumTimeRemainingToAllowSkip_Override = false;
 
-	UPROPERTY(EditAnywhere, meta = (DefaultOverride = MinimumTimeElapsedToAllowSkip))
+    UPROPERTY(EditAnywhere, meta = (DefaultOverride = MinimumTimeElapsedToAllowSkip), Category = "Default")
 	bool bMinimumTimeElapsedToAllowSkip_Override = false;
 
-	UPROPERTY(EditAnywhere, meta = (DefaultOverride = TextWordsPerMinute))
+    UPROPERTY(EditAnywhere, meta = (DefaultOverride = TextWordsPerMinute), Category = "Default")
 	bool bTextWordsPerMinute_Override = false;
-	
-	UPROPERTY(EditAnywhere, meta = (DefaultOverride = TalkModeTitle))
+
+    UPROPERTY(EditAnywhere, meta = (DefaultOverride = TalkModeTitle), Category = "Default")
 	bool bTalkModeTitle_Override = false;
 
-	UPROPERTY(EditAnywhere, meta = (DefaultOverride = PromptModeTitle))
+    UPROPERTY(EditAnywhere, meta = (DefaultOverride = PromptModeTitle), Category = "Default")
 	bool bPromptModeTitle_Override = false;
-	
-	UPROPERTY(EditAnywhere, meta = (DefaultOverride = DialogueWidthAdjustment))
+
+    UPROPERTY(EditAnywhere, meta = (DefaultOverride = DialogueWidthAdjustment), Category = "Default")
 	bool bDialogueWidthAdjustment_Override = false;
-	
-	UPROPERTY(EditAnywhere, meta = (DefaultOverride = GraphDialogueFont))
+
+    UPROPERTY(EditAnywhere, meta = (DefaultOverride = GraphDialogueFont), Category = "Default")
 	bool bGraphDialogueFont_Override = false;
-	
-	UPROPERTY(EditAnywhere, meta = (DefaultOverride = bPreventDialogueTextWrapping))
+
+    UPROPERTY(EditAnywhere, meta = (DefaultOverride = bPreventDialogueTextWrapping), Category = "Default")
 	bool bPreventDialogueTextWrapping_Override = false;
 
-	UPROPERTY(EditAnywhere, meta = (DefaultOverride = bShowTitleTextOnTalkNodes))
+    UPROPERTY(EditAnywhere, meta = (DefaultOverride = bShowTitleTextOnTalkNodes), Category = "Default")
 	bool bShowTitleTextOnTalkNodes_Override = false;
 
-	UPROPERTY(EditAnywhere, meta = (DefaultOverride = bHideTitleTextOnPromptNodes))
+    UPROPERTY(EditAnywhere, meta = (DefaultOverride = bHideTitleTextOnPromptNodes), Category = "Default")
 	bool bHideTitleTextOnPromptNodes_Override = false;
-	
-	UPROPERTY(EditAnywhere, meta = (DefaultOverride = bHideSpeakerSelector))
+
+    UPROPERTY(EditAnywhere, meta = (DefaultOverride = bHideSpeakerSelector), Category = "Default")
 	bool bHideSpeakerSelector_Override = false;
-	
-	UPROPERTY(EditAnywhere, meta = (DefaultOverride = bHideMoodSelector))
+
+    UPROPERTY(EditAnywhere, meta = (DefaultOverride = bHideMoodSelector), Category = "Default")
 	bool bHideMoodSelector_Override = false;
-	
-	UPROPERTY(EditAnywhere, meta = (DefaultOverride = bHideChildSafeButton))
+
+    UPROPERTY(EditAnywhere, meta = (DefaultOverride = bHideChildSafeButton), Category = "Default")
 	bool bHideChildSafeButton_Override = false;
-	
-	UPROPERTY(EditAnywhere, meta = (DefaultOverride = bHideAudioID))
+
+    UPROPERTY(EditAnywhere, meta = (DefaultOverride = bHideAudioID), Category = "Default")
 	bool bHideAudioID_Override = false;
 	
 	// PROPERTY GETTERS


### PR DESCRIPTION
This is a PR that fixes compilation issues with the plugin when targeting shipping/installed builds.

These issues can be seen by packaging the plugin with stricter compiler requirements, as in running (In powershell):

`& "C:\Program Files\Epic Games\UE_5.5\Engine\Build\BatchFiles\RunUAT.bat" BuildPlugin -Plugin="C:\MyUnrealProject\Plugins\UE-Yap\Yap.uplugin" -Package="C:\OutputFolder\UE-Yap" -Rocket -TargetPlatforms=Win64`

Fixes consist in:
- Adding missing #includes
- Adding a "Default" Category to BP exposed UPROPERTY() and UFUNCTION() properties/methods
- Commenting unreachable code in "FlowNode_YapDialogue.cpp"