### PR TITLE
Fix EngineVersion parsing error when launching the editor.

### DIFF
--- a/Yap.uplugin
+++ b/Yap.uplugin
@@ -10,7 +10,7 @@
 	"DocsURL": "",
 	"MarketplaceURL": "",
 	"SupportURL": "",
-	"EngineVersion": "5.5",
+	"EngineVersion": "5.5.0",
 	"CanContainContent": true,
 	"IsBetaVersion": false,
 	"IsExperimentalVersion": false,


### PR DESCRIPTION
This error is shown in the engine console output. Though it doesn't seem to cause any issue.